### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/scripts/generateCommandTypes.mts
+++ b/scripts/generateCommandTypes.mts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFileSync } from 'child_process';
 import type { ContributionsJson } from './contributions/models';
 import { readFileSync, writeFileSync } from 'fs';
 import * as path from 'path';
@@ -56,7 +56,7 @@ export type ContributedKeybindingCommands = ${kbCommands
 	const file = path.join(__dirname, 'src', 'constants.commands.generated.ts');
 	writeFileSync(file, contents, 'utf8');
 	// run prettier on the generated file
-	exec(`pnpm prettier --write ${file}`);
+	execFileSync('pnpm', ['prettier', '--write', file]);
 
 	console.log("Generated 'constants.commands.generated.ts' from contributions.json");
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/1](https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/1)

To fix the issue, the dynamically constructed shell command should be replaced with a safer alternative that avoids shell interpretation of the `file` path. The `execFile` or `execFileSync` method from the `child_process` module should be used instead of `exec`. These methods allow passing arguments as an array, ensuring that special characters in the `file` path are properly escaped and do not alter the intended behavior of the command.

Specifically:
1. Replace the `exec` call with `execFileSync`.
2. Pass `pnpm` as the command and `['prettier', '--write', file]` as the arguments array.
3. Ensure no other functionality is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the script to run formatting commands in a more reliable and synchronous manner. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->