### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-pre.yml
+++ b/.github/workflows/cd-pre.yml
@@ -51,6 +51,10 @@ jobs:
         needs: check
         runs-on: ubuntu-latest
         if: needs.check.outputs.status == 'changed'
+        permissions:
+            contents: read
+            actions: read
+            packages: read
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/3](https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/3)

Add an explicit `permissions` block to the `publish` job in `.github/workflows/cd-pre.yml` so the job does not inherit potentially broad defaults.  
Best minimal fix (without changing behavior) is:

- `contents: read` for checkout/repo read operations.
- `actions: read` because the job uses marketplace actions.
- `packages: read` is safe/minimal and often recommended baseline for package-related workflows.

Place this block directly under `runs-on` (or right after `if`) in the `publish` job. No imports, methods, or dependencies are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit minimal permissions block (contents, actions, packages set to read) to the publish job in the cd-pre workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit, read-only GITHUB_TOKEN permissions to the cd-pre publish job to avoid broad defaults and resolve code scanning alert #3. Sets `contents: read`, `actions: read`, and `packages: read` in `.github/workflows/cd-pre.yml`.

<sup>Written for commit f71ec75d87df03fb095999b36bf0cd0915fe2743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Wbaker7702/vscode-gitlens/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

