### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -26,6 +26,10 @@ on:
   schedule:
     - cron: '40 14 * * 1'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   MSDO:
     # currently only windows latest is supported


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/2](https://github.com/Wbaker7702/vscode-gitlens/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token access is least-privilege and documented.

Best fix here (without changing functionality): set workflow-level permissions right after `name`/`on` (before `jobs`) with:
- `contents: read` (needed for checkout/read repo content)
- `security-events: write` (needed to upload SARIF results to GitHub Security tab)

This keeps behavior intact while constraining token access versus inherited defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit permissions block to the defender-for-devops workflow granting only contents: read and security-events: write.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit `permissions` block to `.github/workflows/defender-for-devops.yml` to fix code scanning alert 2 and limit the `GITHUB_TOKEN` scope. Sets `contents: read` for checkout and `security-events: write` for SARIF upload, keeping behavior the same with least-privilege access.

<sup>Written for commit 02096487b321afd22610d7934d6cd1ee0560bcec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Wbaker7702/vscode-gitlens/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

